### PR TITLE
to fix the windows re direction issue in case of jenkins

### DIFF
--- a/src/main/java/com/hcl/appscan/sdk/scanners/sast/SAClient.java
+++ b/src/main/java/com/hcl/appscan/sdk/scanners/sast/SAClient.java
@@ -23,12 +23,14 @@ import com.hcl.appscan.sdk.logging.DefaultProgress;
 import com.hcl.appscan.sdk.logging.IProgress;
 import com.hcl.appscan.sdk.logging.Message;
 import com.hcl.appscan.sdk.utils.ArchiveUtil;
+import com.hcl.appscan.sdk.utils.FileUtil;
 import com.hcl.appscan.sdk.utils.ServiceUtil;
 import com.hcl.appscan.sdk.utils.SystemUtil;
 
 public class SAClient implements SASTConstants {
 
 	private static final File DEFAULT_INSTALL_DIR = new File(System.getProperty("user.home"), ".appscan"); //$NON-NLS-1$ //$NON-NLS-2$
+	private static final File JENKINS_INSTALL_DIR=new File(System.getProperty("user.dir"),".appscan");//$NON-NLS-1$ //$NON-NLS-2$
 	private static final String SACLIENT = "SAClientUtil"; //$NON-NLS-1$
 	private static final String VERSION_INFO = "version.info"; //$NON-NLS-1$
 	
@@ -44,7 +46,15 @@ public class SAClient implements SASTConstants {
 		m_progress = progress;
 		String install = System.getProperty(CoreConstants.SACLIENT_INSTALL_DIR);
 		m_installDir = install == null ? DEFAULT_INSTALL_DIR : new File(install);
+		
+		//to handle the windows re direction issue in jenkins 
+		if (SystemUtil.isWindows() && m_installDir.toString().toLowerCase().indexOf("system32")>=0) {
+			m_installDir=JENKINS_INSTALL_DIR;
+			
+		}
+		
 	}
+	
 	
 	/**
 	 * Run the SAClient
@@ -152,7 +162,7 @@ public class SAClient implements SASTConstants {
 			ArchiveUtil.unzip(clientZip, m_installDir);
 			m_progress.setStatus(new Message(Message.INFO, Messages.getMessage(DONE)));
 		}
-
+		
 		return new File(findClientInstall(), scriptPath).getAbsolutePath();
 	}
 	


### PR DESCRIPTION
I have tried couple of approaches but this one looks simple and working .

I am changing the install directory to user.dir, when the os is windows and the user.home evaluates to system32 .
user.dir is the jenkins installation directory .Ran few tests found no issue .

Let me know if you find any issue in this approach , i can try something else 