### PR TITLE
use new CountBySeverity api for getting noncompliant issue counts

### DIFF
--- a/src/main/java/com/hcl/appscan/sdk/CoreConstants.java
+++ b/src/main/java/com/hcl/appscan/sdk/CoreConstants.java
@@ -65,6 +65,7 @@ public interface CoreConstants {
 	String API_SACLIENT_VERSION			= "/api/%s/StaticAnalyzer/SAClientUtil?os=%s&meta=%s"; 	//$NON-NLS-1$
 	String API_KEY_PATH					= "/api/ideclientuilogin";								//$NON-NLS-1$
 	String API_REPORT_STATUS			= "/api/V2/Reports/%s";									//$NON-NLS-1$
+	String API_ISSUES_COUNT				= "/api/v2/Issues/CountBySeverity/%s/%s";				//$NON-NLS-1$
 
 	String DEFAULT_RESULT_NAME			= "asoc_results";										//$NON-NLS-1$
 	String SACLIENT_INSTALL_DIR			= "SAClientInstall";									//$NON-NLS-1$
@@ -99,6 +100,7 @@ public interface CoreConstants {
 	String ERROR_INVALID_JOB_ID			= "error.invalid.job.id";								//$NON-NLS-1$
 	String ERROR_SUBMITTING_SCAN		= "error.submit.scan";									//$NON-NLS-1$
 	String ERROR_UPLOADING_FILE			= "error.upload.file";									//$NON-NLS-1$
+	String ERROR_GETTING_INFO			= "error.getting.info";									//$NON-NLS-1$
 	
 	// ASE Status Messages
 	String CREATING_JOB                 = "message.creating.job";                               //$NON-NLS-1$

--- a/src/main/java/com/hcl/appscan/sdk/messages.properties
+++ b/src/main/java/com/hcl/appscan/sdk/messages.properties
@@ -47,6 +47,7 @@ error.delete=Failed to delete {0}.
 error.dom.state=Bad DOM state.
 error.http=Response Code: {0}\nReason: {1}
 error.login.type.deprectated=The specified login type is deprecated. Please use API key and secret.
+error.getting.info=An error occurred getting information for {0} with id {1}.
 
 #Presence
 error.getting.presence.details=An error occurred retrieving details for Presence with id {0}.

--- a/src/main/java/com/hcl/appscan/sdk/results/NonCompliantIssuesResultProvider.java
+++ b/src/main/java/com/hcl/appscan/sdk/results/NonCompliantIssuesResultProvider.java
@@ -54,25 +54,32 @@ public class NonCompliantIssuesResultProvider extends CloudResultsProvider {
 				setHasResult(true);
 			} else if (m_status != null && !(m_status.equalsIgnoreCase(INQUEUE) || m_status.equalsIgnoreCase(RUNNING))) {
 				JSONArray array = m_scanProvider.getNonCompliantIssues(m_scanId);
-				m_totalFindings = array.length();
+				m_totalFindings = 0;
+				
 				for (int i = 0; i < array.length(); i++) {
 					JSONObject jobj = array.getJSONObject(i);
 					String sev = jobj.getString("Severity");
+					int count = jobj.getInt("Count");
+					
 					switch (sev.toLowerCase()) {
 					case "high":
-						m_highFindings++;
+						m_highFindings = count;
+						m_totalFindings += count;
 						break;
 					case "medium":
-						m_mediumFindings++;
+						m_mediumFindings = count;
+						m_totalFindings += count;
 						break;
 					case "low":
-						m_lowFindings++;
+						m_lowFindings = count;
+						m_totalFindings += count;
 						break;
 					case "informational":
-						m_infoFindings++;
+						m_infoFindings = count;
+						m_totalFindings += count;
 						break;
-
 					default:
+						m_totalFindings += count;
 						break;
 					}
 				}

--- a/src/main/java/com/hcl/appscan/sdk/scan/CloudScanServiceProvider.java
+++ b/src/main/java/com/hcl/appscan/sdk/scan/CloudScanServiceProvider.java
@@ -146,7 +146,7 @@ public class CloudScanServiceProvider implements IScanServiceProvider, Serializa
     		HttpClient client = new HttpClient(m_authProvider.getProxy());
     		HttpResponse response = client.get(request_url, request_headers, null);
     		
-    		if (response.getResponseCode() == HttpsURLConnection.HTTP_OK || response.getResponseCode() == HttpsURLConnection.HTTP_CREATED)
+    		if (response.getResponseCode() == HttpsURLConnection.HTTP_OK)
     			return (JSONArray)response.getResponseBodyAsJSON();
 
     		if (response.getResponseCode() == HttpsURLConnection.HTTP_BAD_REQUEST)

--- a/src/main/java/com/hcl/appscan/sdk/scan/CloudScanServiceProvider.java
+++ b/src/main/java/com/hcl/appscan/sdk/scan/CloudScanServiceProvider.java
@@ -134,33 +134,34 @@ public class CloudScanServiceProvider implements IScanServiceProvider, Serializa
 	
         @Override
 	public JSONArray getNonCompliantIssues(String scanId) throws IOException, JSONException {
-		if(loginExpired())
-			return null;
-		
-		String request_url = m_authProvider.getServer() + String.format(API_NONCOMPLIANT_ISSUES, scanId);
-		Map<String, String> request_headers = m_authProvider.getAuthorizationHeader(true);
-		
-		HttpClient client = new HttpClient(m_authProvider.getProxy());
-		HttpResponse response = client.get(request_url, request_headers, null);
-		
-		if (response.getResponseCode() == HttpsURLConnection.HTTP_OK || response.getResponseCode() == HttpsURLConnection.HTTP_CREATED)
-			return (JSONArray)response.getResponseBodyAsJSON();
+        	if(loginExpired())
+    			return null;
+    		
+    		String request_url = m_authProvider.getServer() + String.format(API_ISSUES_COUNT, "Scan", scanId);
+    		request_url += "?applyPolicies=All";
+    		Map<String, String> request_headers = m_authProvider.getAuthorizationHeader(true);
+    		request_headers.put("Content-Type", "application/json; charset=UTF-8");
+    		request_headers.put("Accept", "application/json");
+    		
+    		HttpClient client = new HttpClient(m_authProvider.getProxy());
+    		HttpResponse response = client.get(request_url, request_headers, null);
+    		
+    		if (response.getResponseCode() == HttpsURLConnection.HTTP_OK || response.getResponseCode() == HttpsURLConnection.HTTP_CREATED)
+    			return (JSONArray)response.getResponseBodyAsJSON();
 
-		if (response.getResponseCode() == HttpsURLConnection.HTTP_BAD_REQUEST)
-			m_progress.setStatus(new Message(Message.ERROR, Messages.getMessage(ERROR_INVALID_JOB_ID, scanId)));
-                else {
-                        JSONObject obj=(JSONObject)response.getResponseBodyAsJSON();
-                        if (obj!=null && obj.has(MESSAGE)){
-                            m_progress.setStatus(new Message(Message.ERROR, Messages.getMessage(obj.getString(MESSAGE))));
-                        }
-                        else {
-                            m_progress.setStatus(new Message(Message.ERROR, Messages.getMessage(ERROR_GETTING_RESULT, response.getResponseCode())));
-                        }
-                        
+    		if (response.getResponseCode() == HttpsURLConnection.HTTP_BAD_REQUEST)
+    			m_progress.setStatus(new Message(Message.ERROR, Messages.getMessage(ERROR_GETTING_INFO, "Scan", scanId)));
+            else {
+                JSONObject obj=(JSONObject)response.getResponseBodyAsJSON();
+                if (obj!=null && obj.has(MESSAGE)){
+                    m_progress.setStatus(new Message(Message.ERROR, obj.getString(MESSAGE)));
                 }
-                        
-		
-		return null;
+                else {
+                    m_progress.setStatus(new Message(Message.ERROR, Messages.getMessage(ERROR_GETTING_DETAILS, response.getResponseCode())));
+                }
+            }
+                            
+    		return null;
 	}
 	
 	@Override


### PR DESCRIPTION
Uses the CountBySeverity api for getting noncompliant issue counts instead of the deprecated NonCompliantIssues api.
